### PR TITLE
feat: Design profile pages

### DIFF
--- a/frontend/app/src/main/java/com/example/itda/ui/main/MainScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/main/MainScreen.kt
@@ -14,6 +14,7 @@ import com.example.itda.ui.home.HomeScreen
 import com.example.itda.ui.navigation.BottomNavBar
 import com.example.itda.ui.notification.NotificationScreen
 import com.example.itda.ui.profile.ProfileScreen
+import com.example.itda.ui.profile.ProfileViewModel
 import com.example.itda.ui.search.SearchScreen
 
 // mainscreen 에서 login 여부 보고 분기 -> homescreen / loginscreen
@@ -45,7 +46,8 @@ fun MainScreen(
             composable("notification") { NotificationScreen() }
             composable("profile") {
                 ProfileScreen(
-                    authViewModel = authViewModel
+                    viewModel = ProfileViewModel(),
+                    navController = navController
                 )
             }
 

--- a/frontend/app/src/main/java/com/example/itda/ui/navigation/NavGraphMain.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/navigation/NavGraphMain.kt
@@ -6,6 +6,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.example.itda.ui.auth.AuthViewModel
 import com.example.itda.ui.main.MainScreen
+import com.example.itda.ui.profile.PersonalInfoScreen
+import com.example.itda.ui.profile.PersonalInfoViewModel
+import com.example.itda.ui.profile.ProfileScreen
+import com.example.itda.ui.profile.ProfileViewModel
+import com.example.itda.ui.profile.SettingScreen
+import com.example.itda.ui.profile.SettingViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 
 fun NavGraphBuilder.mainGraph(
@@ -18,6 +25,31 @@ fun NavGraphBuilder.mainGraph(
     ) {
         composable("main_screen") {
             MainScreen(authViewModel = authViewModel)
+        }
+
+        composable("profile") {
+            val viewModel: ProfileViewModel = viewModel()
+            ProfileScreen(
+                viewModel = viewModel,
+                navController = navController
+            )
+        }
+
+        composable("settings") {
+            val viewModel: SettingViewModel = viewModel()
+            SettingScreen(
+                viewModel = viewModel,
+                navController = navController,
+                authViewModel = authViewModel
+            )
+        }
+
+        composable("personal_info") {
+            val viewModel: PersonalInfoViewModel = viewModel()
+            PersonalInfoScreen(
+                viewModel = viewModel,
+                navController = navController
+            )
         }
     }
 }

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoScreen.kt
@@ -1,0 +1,289 @@
+package com.example.itda.ui.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PersonalInfoScreen(
+    viewModel: PersonalInfoViewModel,
+    navController: NavController
+) {
+    val name by viewModel.name.collectAsState()
+    val age by viewModel.age.collectAsState()
+    val gender by viewModel.gender.collectAsState()
+    val address by viewModel.address.collectAsState()
+    val maritalStatus by viewModel.maritalStatus.collectAsState()
+    val education by viewModel.education.collectAsState()
+    val householdSize by viewModel.householdSize.collectAsState()
+    val householdIncome by viewModel.householdIncome.collectAsState()
+    val excludedKeywords by viewModel.excludedKeywords.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("개인정보 수정", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "뒤로가기",
+                            tint = Color(0xFF6B4C7A)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color(0xFFFAF8FC)
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .background(Color(0xFFFAF8FC))
+                .padding(20.dp)
+        ) {
+            // 안내 카드
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(12.dp)),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color(0xFFF0E6F6)
+                )
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.Info,
+                        contentDescription = null,
+                        tint = Color(0xFF6B4C7A),
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        text = "정확한 정보를 입력하시면\n더 나은 정책을 추천받을 수 있어요",
+                        fontSize = 14.sp,
+                        color = Color(0xFF6B4C7A),
+                        lineHeight = 20.sp
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 입력 필드들을 카드로 감싸기
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(16.dp)),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White)
+            ) {
+                Column(modifier = Modifier.padding(20.dp)) {
+                    PersonalInfoFieldStyled(
+                        label = "이름",
+                        value = name,
+                        onValueChange = { viewModel.updateName(it) },
+                        placeholder = "이름을 입력하세요",
+                        icon = Icons.Default.Person
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "나이",
+                        value = age,
+                        onValueChange = { viewModel.updateAge(it) },
+                        placeholder = "나이를 입력하세요",
+                        icon = Icons.Default.DateRange
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "성별",
+                        value = gender,
+                        onValueChange = { viewModel.updateGender(it) },
+                        placeholder = "성별을 입력하세요",
+                        icon = Icons.Default.Face
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "주소지",
+                        value = address,
+                        onValueChange = { viewModel.updateAddress(it) },
+                        placeholder = "주소를 입력하세요",
+                        icon = Icons.Default.Place
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "결혼 여부",
+                        value = maritalStatus,
+                        onValueChange = { viewModel.updateMaritalStatus(it) },
+                        placeholder = "결혼 여부를 입력하세요",
+                        icon = Icons.Default.FavoriteBorder
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "학력",
+                        value = education,
+                        onValueChange = { viewModel.updateEducation(it) },
+                        placeholder = "학력을 입력하세요",
+                        icon = Icons.Default.School
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "가구원 수",
+                        value = householdSize,
+                        onValueChange = { viewModel.updateHouseholdSize(it) },
+                        placeholder = "가구원 수를 입력하세요",
+                        icon = Icons.Default.Home
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "가구원 소득",
+                        value = householdIncome,
+                        onValueChange = { viewModel.updateHouseholdIncome(it) },
+                        placeholder = "가구원 소득을 입력하세요",
+                        icon = Icons.Default.AccountBalance
+                    )
+
+                    PersonalInfoFieldStyled(
+                        label = "제외 알고리즘",
+                        value = excludedKeywords,
+                        onValueChange = { viewModel.updateExcludedKeywords(it) },
+                        placeholder = "제외할 키워드를 입력하세요",
+                        icon = Icons.Default.Close,
+                        isLast = true
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 완료 버튼
+            Button(
+                onClick = {
+                    viewModel.savePersonalInfo()
+                    navController.popBackStack()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .shadow(4.dp, RoundedCornerShape(12.dp)),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF9C7BA8)
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    "완료",
+                    color = Color.White,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+fun PersonalInfoFieldStyled(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    icon: ImageVector,
+    isLast: Boolean = false
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(bottom = 8.dp)
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = Color(0xFF9C7BA8),
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = label,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color(0xFF2D2D2D)
+            )
+        }
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = {
+                Text(
+                    placeholder,
+                    color = Color(0xFFBDBDBD),
+                    fontSize = 15.sp
+                )
+            },
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = Color(0xFF9C7BA8),
+                unfocusedBorderColor = Color(0xFFE0E0E0),
+                focusedContainerColor = Color(0xFFFAF8FC),
+                unfocusedContainerColor = Color.White,
+                focusedTextColor = Color(0xFF2D2D2D),
+                unfocusedTextColor = Color(0xFF2D2D2D)
+            ),
+            shape = RoundedCornerShape(12.dp)
+        )
+        if (!isLast) {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun PersonalInfoScreenPreview() {
+    PersonalInfoScreen(
+        viewModel = PersonalInfoViewModel(),
+        navController = rememberNavController()
+    )
+}

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoViewModel.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoViewModel.kt
@@ -1,0 +1,51 @@
+package com.example.itda.ui.profile
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+
+class PersonalInfoViewModel : ViewModel() {
+
+    private val _name = MutableStateFlow("")
+    val name: StateFlow<String> = _name
+
+    private val _age = MutableStateFlow("")
+    val age: StateFlow<String> = _age
+
+    private val _gender = MutableStateFlow("")
+    val gender: StateFlow<String> = _gender
+
+    private val _address = MutableStateFlow("")
+    val address: StateFlow<String> = _address
+
+    private val _maritalStatus = MutableStateFlow("")
+    val maritalStatus: StateFlow<String> = _maritalStatus
+
+    private val _education = MutableStateFlow("")
+    val education: StateFlow<String> = _education
+
+    private val _householdSize = MutableStateFlow("")
+    val householdSize: StateFlow<String> = _householdSize
+
+    private val _householdIncome = MutableStateFlow("")
+    val householdIncome: StateFlow<String> = _householdIncome
+
+    private val _excludedKeywords = MutableStateFlow("")
+    val excludedKeywords: StateFlow<String> = _excludedKeywords
+
+    fun updateName(value: String) { _name.value = value }
+    fun updateAge(value: String) { _age.value = value }
+    fun updateGender(value: String) { _gender.value = value }
+    fun updateAddress(value: String) { _address.value = value }
+    fun updateMaritalStatus(value: String) { _maritalStatus.value = value }
+    fun updateEducation(value: String) { _education.value = value }
+    fun updateHouseholdSize(value: String) { _householdSize.value = value }
+    fun updateHouseholdIncome(value: String) { _householdIncome.value = value }
+    fun updateExcludedKeywords(value: String) { _excludedKeywords.value = value }
+
+    fun savePersonalInfo() {
+        // TODO: Repository에 저장하는 로직
+        // 지금은 UI만 구현하므로 실제 저장 로직은 나중에 API 연동 시 추가
+    }
+}

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileScreen.kt
@@ -1,70 +1,279 @@
 package com.example.itda.ui.profile
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.itda.ui.auth.AuthViewModel
-import com.example.itda.ui.common.components.BaseScreen
-import com.example.itda.ui.common.components.ScreenContract
-import com.example.itda.ui.common.theme.Neutral20
-import com.example.itda.ui.common.theme.Neutral90
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 
-object ProfileContract : ScreenContract {
-    override val route = "profile"
-    override val title = "Profile"
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    viewModel: ProfileViewModel,
+    navController: NavController
+) {
+    val userInfo by viewModel.userInfo.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Profile", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
+                actions = {
+                    IconButton(
+                        onClick = { navController.navigate("settings") },
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = "설정",
+                            tint = Color(0xFF6B4C7A)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color(0xFFFAF8FC)
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .background(Color(0xFFFAF8FC))
+                .padding(20.dp)
+        ) {
+            // 사용자 프로필 카드
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(4.dp, RoundedCornerShape(16.dp)),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(70.dp)
+                            .clip(CircleShape)
+                            .background(
+                                androidx.compose.ui.graphics.Brush.linearGradient(
+                                    colors = listOf(Color(0xFFE0BBE4), Color(0xFF9C7BA8))
+                                )
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            Icons.Default.Person,
+                            contentDescription = null,
+                            modifier = Modifier.size(40.dp),
+                            tint = Color.White
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(16.dp))
+
+                    Column {
+                        Text(
+                            text = userInfo.userName,
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF2D2D2D)
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = userInfo.userId,
+                            fontSize = 14.sp,
+                            color = Color(0xFF9E9E9E)
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            // 맞춤 정보 헤더
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(12.dp)),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color(0xFFF0E6F6)
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Default.Info,
+                                contentDescription = null,
+                                tint = Color(0xFF6B4C7A),
+                                modifier = Modifier.size(20.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "맞춤 정보",
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF6B4C7A)
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "정책 추천을 위한 개인정보",
+                            fontSize = 12.sp,
+                            color = Color(0xFF8B6B9A)
+                        )
+                    }
+                    Button(
+                        onClick = { navController.navigate("personal_info") },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF9C7BA8)
+                        ),
+                        shape = RoundedCornerShape(10.dp),
+                        elevation = ButtonDefaults.buttonElevation(4.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("수정", fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // 정보 카드
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(16.dp)),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White)
+            ) {
+                Column(modifier = Modifier.padding(20.dp)) {
+                    ProfileInfoItemStyled("이름", userInfo.name, Icons.Default.Person)
+                    ProfileInfoItemStyled("유신청", userInfo.category, Icons.Default.CheckCircle)
+                    ProfileInfoItemStyled("나이", "${userInfo.age}세", Icons.Default.DateRange)
+                    ProfileInfoItemStyled("성별", userInfo.gender, Icons.Default.Face)
+                    ProfileInfoItemStyled("주소지", userInfo.address, Icons.Default.Place)
+                    ProfileInfoItemStyled("결혼 여부", userInfo.maritalStatus, Icons.Default.FavoriteBorder)
+                    ProfileInfoItemStyled("학력", userInfo.education, Icons.Default.School)
+                    ProfileInfoItemStyled("가구원 수", "${userInfo.householdSize}인", Icons.Default.Home)
+                    ProfileInfoItemStyled("가구원 소득", "${userInfo.householdIncome}만원", Icons.Default.AccountBalance)
+                    ProfileInfoItemStyled(
+                        "제외 알고리즘",
+                        userInfo.excludedKeywords.ifEmpty { "없음" },
+                        Icons.Default.Close,
+                        isLast = true
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
 }
 
 @Composable
-fun ProfileScreen(
-    authViewModel: AuthViewModel
+fun ProfileInfoItemStyled(
+    label: String,
+    value: String,
+    icon: ImageVector,
+    isLast: Boolean = false
 ) {
-    BaseScreen("Profile") { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxSize()
-                .padding(horizontal = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
         ) {
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text("프로필 화면", style = MaterialTheme.typography.headlineMedium)
-
-
-            Button(
-                onClick = {
-                    /* TODO: 로그아웃 API 연결 */
-                    authViewModel.logout()
-                },
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Neutral90,
-                )
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFF0E6F6)),
+                contentAlignment = Alignment.Center
             ) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    tint = Color(0xFF9C7BA8),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    "로그아웃",
+                    text = label,
+                    fontSize = 13.sp,
+                    color = Color(0xFF9E9E9E),
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = value,
                     fontSize = 16.sp,
-                    fontWeight = FontWeight.Medium,
-                    color = Neutral20
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color(0xFF2D2D2D)
                 )
             }
         }
+        if (!isLast) {
+            Spacer(modifier = Modifier.height(12.dp))
+            HorizontalDivider(
+                color = Color(0xFFF0F0F0),
+                thickness = 1.dp
+            )
+        }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun ProfileScreenPreview() {
+    ProfileScreen(
+        viewModel = ProfileViewModel(),
+        navController = rememberNavController()
+    )
 }

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileViewModel.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileViewModel.kt
@@ -1,4 +1,36 @@
 package com.example.itda.ui.profile
 
-class ProfileViewModel {
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+data class UserInfo(
+    val userName: String = "User_name",
+    val userId: String = "user_id",
+    val name: String = "유신청",
+    val category: String = "유신청",
+    val age: Int = 25,
+    val gender: String = "남성",
+    val address: String = "서울특별시 광악구 신림동 94-60",
+    val maritalStatus: String = "미혼",
+    val education: String = "고졸",
+    val householdSize: Int = 1,
+    val householdIncome: String = "n",
+    val excludedKeywords: String = ""
+)
+
+class ProfileViewModel : ViewModel() {
+
+    private val _userInfo = MutableStateFlow(UserInfo())
+    val userInfo: StateFlow<UserInfo> = _userInfo
+
+    // 나중에 API 연동 시 사용할 함수들
+    fun loadUserInfo() {
+        // TODO: Repository에서 사용자 정보 불러오기
+    }
+
+    fun updateUserInfo(newInfo: UserInfo) {
+        // TODO: Repository에 사용자 정보 저장
+        _userInfo.value = newInfo
+    }
 }

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/SettingScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/SettingScreen.kt
@@ -1,0 +1,374 @@
+package com.example.itda.ui.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.itda.ui.auth.AuthViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingScreen(
+    viewModel: SettingViewModel,
+    navController: NavController,
+    authViewModel: AuthViewModel
+) {
+    val darkMode by viewModel.darkMode.collectAsState()
+    val alarmEnabled by viewModel.alarmEnabled.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Setting", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "뒤로가기",
+                            tint = Color(0xFF6B4C7A)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color(0xFFFAF8FC)
+                )
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .background(Color(0xFFFAF8FC))
+                .padding(20.dp)
+        ) {
+            // 계정 설정
+            SettingSectionTitle("계정 설정", Icons.Default.AccountCircle)
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(16.dp)),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White)
+            ) {
+                Column(modifier = Modifier.padding(4.dp)) {
+                    SettingToggleItemStyled(
+                        title = "다크 모드",
+                        icon = Icons.Default.Star,
+                        checked = darkMode,
+                        onCheckedChange = { viewModel.toggleDarkMode() }
+                    )
+                    HorizontalDivider(
+                        color = Color(0xFFF0F0F0),
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                    SettingToggleItemStyled(
+                        title = "알림 설정",
+                        icon = Icons.Default.Notifications,
+                        checked = alarmEnabled,
+                        onCheckedChange = { viewModel.toggleAlarm() }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 이용 안내
+            SettingSectionTitle("이용 안내", Icons.Default.Info)
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(16.dp)),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White)
+            ) {
+                Column(modifier = Modifier.padding(4.dp)) {
+                    SettingMenuItemStyled("공지사항", Icons.Default.Notifications) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("자주 묻는 질문", Icons.Default.Email) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("고객 문의", Icons.Default.Call) { }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 이용 정보
+            SettingSectionTitle("이용 정보", Icons.Default.Create)
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .shadow(2.dp, RoundedCornerShape(16.dp)),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color.White)
+            ) {
+                Column(modifier = Modifier.padding(4.dp)) {
+                    SettingMenuItemStyled("이용 약관", Icons.Default.Build) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("개인정보 처리방침", Icons.Default.Lock) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("개인정보 수집/이용 동의", Icons.Default.CheckCircle) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("만14세 수집/이용 동의", Icons.Default.CheckCircle) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("위치기반서비스 이용약관", Icons.Default.Place) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("마케팅 이용동의", Icons.Default.Send) { }
+                    HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                    SettingMenuItemStyled("로그아웃", Icons.Default.Favorite) { }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+fun SettingSectionTitle(title: String, icon: ImageVector) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(horizontal = 4.dp)
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = Color(0xFF9C7BA8),
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = title,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color(0xFF2D2D2D)
+        )
+    }
+}
+
+@Composable
+fun SettingToggleItemStyled(
+    title: String,
+    icon: ImageVector,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f)
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = Color(0xFF9C7BA8),
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = title,
+                fontSize = 16.sp,
+                color = Color(0xFF2D2D2D),
+                fontWeight = FontWeight.Medium
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = Color(0xFF9C7BA8),
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = Color(0xFFCCCCCC)
+            )
+        )
+    }
+}
+
+@Composable
+fun SettingMenuItemStyled(title: String, icon: ImageVector, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f)
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = Color(0xFF9C7BA8),
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = title,
+                fontSize = 16.sp,
+                color = Color(0xFF2D2D2D),
+                fontWeight = FontWeight.Medium
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = Color(0xFFBDBDBD)
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+fun SettingScreenPreview() {
+    MaterialTheme {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Setting", fontWeight = FontWeight.Bold) },
+                    navigationIcon = {
+                        IconButton(onClick = { }) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "뒤로가기")
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color(0xFFFAF8FC)
+                    )
+                )
+            }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .background(Color(0xFFFAF8FC))
+                    .padding(20.dp)
+            ) {
+                // 계정 설정
+                SettingSectionTitle("계정 설정", Icons.Default.AccountCircle)
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(2.dp, RoundedCornerShape(16.dp)),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White)
+                ) {
+                    Column(modifier = Modifier.padding(4.dp)) {
+                        SettingToggleItemStyled(
+                            title = "다크 모드",
+                            icon = Icons.Default.Star,
+                            checked = false,
+                            onCheckedChange = {  }
+                        )
+                        HorizontalDivider(
+                            color = Color(0xFFF0F0F0),
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                        SettingToggleItemStyled(
+                            title = "알림 설정",
+                            icon = Icons.Default.Notifications,
+                            checked = true,
+                            onCheckedChange = {  }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // 이용 안내
+                SettingSectionTitle("이용 안내", Icons.Default.Info)
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(2.dp, RoundedCornerShape(16.dp)),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White)
+                ) {
+                    Column(modifier = Modifier.padding(4.dp)) {
+                        SettingMenuItemStyled("공지사항", Icons.Default.Notifications) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("자주 묻는 질문", Icons.Default.Email) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("고객 문의", Icons.Default.Call) { }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // 이용 정보
+                SettingSectionTitle("이용 정보", Icons.Default.Create)
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(2.dp, RoundedCornerShape(16.dp)),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White)
+                ) {
+                    Column(modifier = Modifier.padding(4.dp)) {
+                        SettingMenuItemStyled("이용 약관", Icons.Default.Build) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("개인정보 처리방침", Icons.Default.Lock) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("개인정보 수집/이용 동의", Icons.Default.CheckCircle) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("만14세 수집/이용 동의", Icons.Default.CheckCircle) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("위치기반서비스 이용약관", Icons.Default.Place) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("마케팅 이용동의", Icons.Default.Send) { }
+                        HorizontalDivider(color = Color(0xFFF0F0F0), modifier = Modifier.padding(horizontal = 16.dp))
+                        SettingMenuItemStyled("로그아웃", Icons.Default.Favorite) { }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/SettingViewModel.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/SettingViewModel.kt
@@ -1,0 +1,24 @@
+package com.example.itda.ui.profile
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class SettingViewModel : ViewModel() {
+
+    private val _darkMode = MutableStateFlow(false)
+    val darkMode: StateFlow<Boolean> = _darkMode
+
+    private val _alarmEnabled = MutableStateFlow(true)
+    val alarmEnabled: StateFlow<Boolean> = _alarmEnabled
+
+    fun toggleDarkMode() {
+        _darkMode.value = !_darkMode.value
+        // TODO: 실제로 다크모드 적용 로직
+    }
+
+    fun toggleAlarm() {
+        _alarmEnabled.value = !_alarmEnabled.value
+        // TODO: 실제로 알림 설정 변경 로직
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- #36: fe/feat/36-design-profile-pages

## ✨ 주요 변경 사항
- 프론트엔드: Profile pages design

---

## 📋 작업 내용
### 추가/변경된 내용
- <Profile pages>
    - Profile page
    - Setting page
    - Personal Info page

### 작업 상세 설명
1. **Profile page**: <Profile page입니다. setting icon을 누르면 setting page, 수정 버튼을 누르면 personal info page로 navigate 됩니다.>
2. **Setting page**: <Setting page입니다. 여러 설정이나 공지사항 등에 접근할 수 있습니다.>
3. **Personal Info page**: <Personal info page입니다. 본인의 개인정보를 수정할 수 있습니다.>

---

## ✅ 체크리스트
- [V ] 코드가 잘 빌드됨
- [V] Linter
- [V] 모든 테스트 통과

