### PR TITLE
fix(fe) #46 : fix profile page construction

### DIFF
--- a/frontend/app/src/main/java/com/example/itda/ui/navigation/NavGraphMain.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/navigation/NavGraphMain.kt
@@ -2,8 +2,10 @@ package com.example.itda.ui.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
@@ -11,10 +13,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.example.itda.ui.auth.AuthViewModel
+import com.example.itda.ui.common.theme.Neutral100
 import com.example.itda.ui.feed.FeedRoute
 import com.example.itda.ui.home.HomeRoute
 import com.example.itda.ui.notification.NotificationScreen
-import com.example.itda.ui.profile.ProfileScreen
+import com.example.itda.ui.profile.PersonalInfoScreen
+import com.example.itda.ui.profile.ProfileRoute
+import com.example.itda.ui.profile.SettingsRoute
 import com.example.itda.ui.search.SearchScreen
 
 // Bottom Navigation 탭의 경로 목록을 정의합니다.
@@ -37,10 +42,7 @@ fun NavGraphBuilder.mainGraph(
                 MainScaffoldWrapper(navController = navController) { innerPadding ->
                     when (route) {
                         "home" -> HomeRoute(
-                            onFeedClick = { feedId ->
-                                // 상세 화면은 Wrapper 없이 바로 이동
-                                navController.navigate("feed/$feedId")
-                            },
+                            onFeedClick = { feedId -> navController.navigate("feed/$feedId") },
                             modifier = Modifier.padding(innerPadding)
                         )
                         "search" -> SearchScreen(
@@ -49,8 +51,10 @@ fun NavGraphBuilder.mainGraph(
                         "notification" -> NotificationScreen(
                             //modifier = Modifier.padding(innerPadding)
                          )
-                        "profile" -> ProfileScreen( // 🌟 ProfileRoute로 감싸는 것이 이상적
-                            // modifier = Modifier.padding(innerPadding)
+                        "profile" -> ProfileRoute(
+                            onSettingClick = { navController.navigate("settings") },
+                            onPersonalInfoClick = { navController.navigate("personal_info") },
+                            modifier=  Modifier.padding(innerPadding),
                         )
                     }
                 }
@@ -72,30 +76,18 @@ fun NavGraphBuilder.mainGraph(
             }
         }
 
-//        composable("profile") {
-//            val viewModel: ProfileViewModel = viewModel()
-//            ProfileScreen(
-//                viewModel = viewModel,
-//                navController = navController
-//            )
-//        }
-//
-//        composable("settings") {
-//            val viewModel: SettingViewModel = viewModel()
-//            SettingScreen(
-//                viewModel = viewModel,
-//                navController = navController,
-//                authViewModel = authViewModel
-//            )
-//        }
-//
-//        composable("personal_info") {
-//            val viewModel: PersonalInfoViewModel = viewModel()
-//            PersonalInfoScreen(
-//                viewModel = viewModel,
-//                navController = navController
-//            )
-//        }
+        composable("settings") {
+            SettingsRoute(
+                onBack = { navController.popBackStack() },
+            )
+        }
+
+        composable("personal_info") {
+            PersonalInfoScreen(
+                onBack = { navController.popBackStack() },
+            )
+        }
+
     }
 }
 
@@ -108,5 +100,10 @@ fun MainScaffoldWrapper(
     // 하지만, NavGraphMain에서 Scaffold Wrapper를 사용할 때,
     // BottomBar가 필요 없는 경로는 Wrapper를 사용하지 않도록 설계하는 것이 더 깔끔합니다.
     // 여기서는 BottomNavBar가 필요한 탭 화면을 감싸는 역할만 수행합니다.
-
+    Scaffold(
+        bottomBar = { BottomNavBar(navController = navController) }, // 👈 BottomNavBar가 여기에 위치
+        containerColor = Neutral100, // 배경색
+    ) { innerPadding -> // 👈 BottomBar의 높이만큼 계산된 PaddingValues가 innerPadding으로 제공됨
+        content(innerPadding) // 👈 이 innerPadding이 content 람다를 통해 Route로 전달됩니다.
+    }
 }

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoScreen.kt
@@ -1,14 +1,44 @@
 package com.example.itda.ui.profile
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.filled.AccountBalance
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -18,18 +48,19 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
+import androidx.hilt.navigation.compose.hiltViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PersonalInfoScreen(
-    viewModel: PersonalInfoViewModel,
-    navController: NavController
+//    ui : PersonalInfoViewModel.ProfileInfoView,
+    onBack : () -> Unit,
+    modifier : Modifier = Modifier,
 ) {
+    val viewModel: PersonalInfoViewModel = hiltViewModel()
+
     val name by viewModel.name.collectAsState()
     val age by viewModel.age.collectAsState()
     val gender by viewModel.gender.collectAsState()
@@ -45,7 +76,7 @@ fun PersonalInfoScreen(
             TopAppBar(
                 title = { Text("개인정보 수정", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
                 navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
+                    IconButton(onClick = onBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "뒤로가기",
@@ -189,7 +220,7 @@ fun PersonalInfoScreen(
             Button(
                 onClick = {
                     viewModel.savePersonalInfo()
-                    navController.popBackStack()
+                    onBack
                 },
                 modifier = Modifier
                     .fillMaxWidth()
@@ -278,12 +309,12 @@ fun PersonalInfoFieldStyled(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Preview(showBackground = true)
-@Composable
-fun PersonalInfoScreenPreview() {
-    PersonalInfoScreen(
-        viewModel = PersonalInfoViewModel(),
-        navController = rememberNavController()
-    )
-}
+//@OptIn(ExperimentalMaterial3Api::class)
+//@Preview(showBackground = true)
+//@Composable
+//fun PersonalInfoScreenPreview() {
+//    PersonalInfoScreen(
+//        viewModel = PersonalInfoViewModel(),
+//        navController = rememberNavController()
+//    )
+//}

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoViewModel.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/PersonalInfoViewModel.kt
@@ -1,11 +1,17 @@
 package com.example.itda.ui.profile
 
 import androidx.lifecycle.ViewModel
+import com.example.itda.data.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 
-class PersonalInfoViewModel : ViewModel() {
+@HiltViewModel
+class PersonalInfoViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
 
     private val _name = MutableStateFlow("")
     val name: StateFlow<String> = _name

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileRoute.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileRoute.kt
@@ -1,0 +1,55 @@
+package com.example.itda.ui.profile
+
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun ProfileRoute(
+    onSettingClick : () -> Unit,
+    onPersonalInfoClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    vm: ProfileViewModel = hiltViewModel()
+) {
+    val ui by vm.profileUi.collectAsState() // ViewModel의 UI 상태를 구독
+    val scope = rememberCoroutineScope()
+
+    ProfileScreen(
+        ui = ui, // ProfileScreen에 UI 상태를 통째로 전달
+        onPersonalInfoClick = onPersonalInfoClick,
+        onSettingClick = onSettingClick,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun SettingsRoute(
+    onBack : () -> Unit,
+    vm: SettingsViewModel = hiltViewModel()
+) {
+    val ui by vm.settingsUi.collectAsState()
+
+    SettingScreen(
+        ui = ui,
+        onBack = onBack,
+        toggleDarkMode = { vm::toggleDarkMode },
+        toggleAlarm = { vm::toggleAlarm }
+    )
+}
+
+@Composable
+fun PersonalInfoRoute(
+    onBack : () -> Unit,
+    vm: PersonalInfoViewModel = hiltViewModel()
+) {
+//    val ui by vm.personalInfoUi.collectAsState()
+
+    PersonalInfoScreen(
+        onBack = onBack
+//        viewModel = viewModel,
+    )
+}

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/ProfileScreen.kt
@@ -47,10 +47,12 @@ import androidx.compose.ui.unit.sp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileScreen(
-//    viewModel: ProfileViewModel,
-//    navController: NavController
+    ui : ProfileViewModel.ProfileUiState,
+    onSettingClick : () -> Unit,
+    onPersonalInfoClick : () -> Unit,
+    modifier : Modifier = Modifier,
 ) {
-//    val userInfo by viewModel.userInfo.collectAsState()
+
 
     Scaffold(
         topBar = {
@@ -58,9 +60,7 @@ fun ProfileScreen(
                 title = { Text("Profile", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
                 actions = {
                     IconButton(
-                        onClick = {
-//                            navController.navigate("settings")
-                        },
+                        onClick = onSettingClick,
                         modifier = Modifier
                             .padding(end = 8.dp)
                     ) {
@@ -180,9 +180,7 @@ fun ProfileScreen(
                         )
                     }
                     Button(
-                        onClick = {
-//                            navController.navigate("personal_info")
-                        },
+                        onClick = onPersonalInfoClick,
                         colors = ButtonDefaults.buttonColors(
                             containerColor = Color(0xFF9C7BA8)
                         ),

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/SettingScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/SettingScreen.kt
@@ -2,18 +2,49 @@ package com.example.itda.ui.profile
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -23,26 +54,23 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
-import com.example.itda.ui.auth.AuthViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingScreen(
-    viewModel: SettingViewModel,
-    navController: NavController,
-    authViewModel: AuthViewModel
+    ui : SettingsViewModel.SettingsUiState,
+    onBack : () -> Unit,
+    toggleDarkMode : () -> Unit,
+    toggleAlarm : () -> Unit,
+    modifier : Modifier = Modifier,
 ) {
-    val darkMode by viewModel.darkMode.collectAsState()
-    val alarmEnabled by viewModel.alarmEnabled.collectAsState()
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Setting", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
                 navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
+                    IconButton(onClick = onBack) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "뒤로가기",
@@ -79,8 +107,8 @@ fun SettingScreen(
                     SettingToggleItemStyled(
                         title = "다크 모드",
                         icon = Icons.Default.Star,
-                        checked = darkMode,
-                        onCheckedChange = { viewModel.toggleDarkMode() }
+                        checked = ui.darkMode,
+                        onCheckedChange = { toggleDarkMode() }
                     )
                     HorizontalDivider(
                         color = Color(0xFFF0F0F0),
@@ -89,8 +117,8 @@ fun SettingScreen(
                     SettingToggleItemStyled(
                         title = "알림 설정",
                         icon = Icons.Default.Notifications,
-                        checked = alarmEnabled,
-                        onCheckedChange = { viewModel.toggleAlarm() }
+                        checked = ui.alarmEnabled,
+                        onCheckedChange = { toggleAlarm() }
                     )
                 }
             }

--- a/frontend/app/src/main/java/com/example/itda/ui/profile/SettingViewModel.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/profile/SettingViewModel.kt
@@ -1,24 +1,62 @@
 package com.example.itda.ui.profile
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.itda.data.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
-class SettingViewModel : ViewModel() {
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
 
-    private val _darkMode = MutableStateFlow(false)
-    val darkMode: StateFlow<Boolean> = _darkMode
+    data class SettingsUiState(
+        val darkMode : Boolean = false,
+        val alarmEnabled : Boolean = true,
+        val isLoading : Boolean = false,
+    )
 
-    private val _alarmEnabled = MutableStateFlow(true)
-    val alarmEnabled: StateFlow<Boolean> = _alarmEnabled
+
+    private val _settingsUi = MutableStateFlow(SettingsUiState())
+    val settingsUi: StateFlow<SettingsUiState> = _settingsUi.asStateFlow()
+
 
     fun toggleDarkMode() {
-        _darkMode.value = !_darkMode.value
-        // TODO: 실제로 다크모드 적용 로직
+        viewModelScope.launch {
+            _settingsUi.update { it.copy( isLoading = true) }
+
+             val darkMode = !_settingsUi.value.darkMode
+            // TODO: 실제로 다크모드 적용 로직
+
+            _settingsUi.update {
+                it.copy(
+                    darkMode = darkMode,
+                    isLoading = false
+                )
+            }
+        }
     }
 
     fun toggleAlarm() {
-        _alarmEnabled.value = !_alarmEnabled.value
-        // TODO: 실제로 알림 설정 변경 로직
+        viewModelScope.launch {
+            _settingsUi.update { it.copy( isLoading = true) }
+
+            val alarmEnabled = !_settingsUi.value.alarmEnabled
+            // TODO: 실제로 알림 설정 변경 로직
+
+            _settingsUi.update {
+                it.copy(
+                    darkMode = alarmEnabled,
+                    isLoading = false
+                )
+            }
+        }
     }
+
 }


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #46 

## ✨ 주요 변경 사항
- 프론트엔드: 프로필 페이지 routing 구조 변경

---

## 📋 작업 내용
### 추가/변경된 내용
- Profile 관련 페이지들의 라우팅 조정
- Profile 관련 페이지들의 Viewmodel 독립성 확보

### 작업 상세 설명
1. **Profile Page routing 조정**: NavGraphMain 을 통해 진입하던 로직을 ProfileRoute.kt 의 각각의 Route를 타고 Profile, Setting,  PersonalInfo Screen으로 이동되도록 함. 
2. **Viewmodel 독립성 확보**: Viewmodel 의 UiState를 받아오고 상위에서 콜백함수로  모든 동작을 넘겨줘서 screen에서는 ui 만 관리할 수 있도록 함.

---

## ✅ 체크리스트
- [x] 코드가 잘 빌드됨
- [x] Linter
- [x] 모든 테스트 통과

---

## ⚠️ 주의 사항
- 반드시 이 PR을 fe/feat/46 -> fe/fix/29 으로 먼저 병합하고, 그 다음에 fe/fix/29를 main으로 병합해주세요. 반드시.

---

## 📎 참고 자료

