### PR TITLE
be(feat) #49 : send errorMessages to client

### DIFF
--- a/backend/src/main/kotlin/com/example/itda/DomainException.kt
+++ b/backend/src/main/kotlin/com/example/itda/DomainException.kt
@@ -1,0 +1,18 @@
+package com.example.itda
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+
+open class DomainException(
+    val code: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR,
+    override val message: String,
+) : RuntimeException(message) {
+    override fun toString(): String {
+        return "DomainException(msg='$message', errorCode=$code)"
+    }
+}
+
+data class ErrorResponse(
+    val code: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR,
+    val message: String,
+)

--- a/backend/src/main/kotlin/com/example/itda/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/example/itda/GlobalExceptionHandler.kt
@@ -1,0 +1,21 @@
+package com.example.itda
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(DomainException::class)
+    fun handleDomainException(ex: DomainException): ResponseEntity<ErrorResponse> {
+        val httpStatus = ex.code.value()
+        val errorResponse =
+            ErrorResponse(
+                code = ex.code,
+                message = ex.message,
+            )
+        return ResponseEntity
+            .status(httpStatus)
+            .body(errorResponse)
+    }
+}

--- a/backend/src/main/kotlin/com/example/itda/user/UserException.kt
+++ b/backend/src/main/kotlin/com/example/itda/user/UserException.kt
@@ -1,12 +1,13 @@
 package com.example.itda.user
 
+import com.example.itda.DomainException
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 
 sealed class UserException(
     code: HttpStatusCode,
     message: String,
-) : RuntimeException(message)
+) : DomainException(code, message)
 
 class AuthenticateException : UserException(
     code = HttpStatus.UNAUTHORIZED,


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #49 

## ✨ 주요 변경 사항
- 백엔드: 에러메세지 클라한테 가도록 구현

---

## 📋 작업 내용
### 추가/변경된 내용
- 공통 Exception class 생성
- ExceptionHandler 생성

### 작업 상세 설명
1. **공통 Exception class 생성**: 
```
open class DomainException(
    val code: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR,
    override val message: String,
) : RuntimeException(message)
```
라는 exception class 만들었습니다. 앞으로 exception 새로 만들어서 처리할 때
```
sealed class UserException(
    code: HttpStatusCode,
    message: String,
) : DomainException(code, message)

class AuthenticateException : UserException(
    code = HttpStatus.UNAUTHORIZED,
    message = "Authenticate failed",
)
```
이런 식으로 만들어서 써주세요.

2. **ExceptionHandler 생성**: 
에러 발생 시 클라한테
```
data class ErrorResponse(
    val code: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR,
    val message: String,
)
```
형태로 보냅니다.
---

## ✅ 체크리스트
- [x] 코드가 잘 빌드됨
- [x] Linter
- [x] 모든 테스트 통과

---

## ⚠️ 주의 사항
.
---

## 📎 참고 자료
.