### PR TITLE
feat(be) #70 : user preference api

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
     implementation("com.google.cloud.sql:postgres-socket-factory:1.25.3")
     implementation("com.pgvector:pgvector:0.1.4")
+    implementation("org.hibernate.orm:hibernate-vector:6.6.29.Final")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/backend/src/main/kotlin/com/example/itda/program/ProgramException.kt
+++ b/backend/src/main/kotlin/com/example/itda/program/ProgramException.kt
@@ -1,0 +1,15 @@
+package com.example.itda.program
+
+import com.example.itda.DomainException
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+
+sealed class ProgramException(
+    code: HttpStatusCode,
+    message: String,
+) : DomainException(code, message)
+
+class ProgramNotFoundException : ProgramException(
+    code = HttpStatus.NOT_FOUND,
+    message = "Program not found",
+)

--- a/backend/src/main/kotlin/com/example/itda/program/persistence/ProgramEntity.kt
+++ b/backend/src/main/kotlin/com/example/itda/program/persistence/ProgramEntity.kt
@@ -5,7 +5,6 @@ import com.example.itda.program.persistence.enums.EmploymentStatus
 import com.example.itda.program.persistence.enums.Gender
 import com.example.itda.program.persistence.enums.MaritalStatus
 import com.example.itda.program.persistence.enums.ProgramCategory
-import com.pgvector.PGvector
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -14,6 +13,9 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.Array
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.time.OffsetDateTime
 
 @Entity
@@ -81,6 +83,8 @@ class ProgramEntity(
     var createdAt: OffsetDateTime? = null,
     @Column(name = "operating_entity", nullable = false)
     var operatingEntity: String,
-    @Column(columnDefinition = "vector(1024)", nullable = false)
-    var embedding: PGvector,
+    @Column(nullable = false)
+    @JdbcTypeCode(SqlTypes.VECTOR)
+    @Array(length = 1024)
+    var embedding: FloatArray,
 )

--- a/backend/src/main/kotlin/com/example/itda/user/controller/UserController.kt
+++ b/backend/src/main/kotlin/com/example/itda/user/controller/UserController.kt
@@ -54,6 +54,15 @@ class UserController(
         )
         return ResponseEntity.ok().build()
     }
+
+    @PostMapping("/update/preferences")
+    fun updateUserPreferences(
+        @AuthUser user: User,
+        @RequestBody request: UserPreferenceUpdateRequest,
+    ): ResponseEntity<Void> {
+        userService.updateUserPreferenceVector(user.id, request.satisfactionScores)
+        return ResponseEntity.ok().build()
+    }
 }
 
 data class AuthRequest(
@@ -78,4 +87,8 @@ data class ProfileRequest(
     val householdSize: Int?,
     val householdIncome: Int?,
     val employmentStatus: EmploymentStatus?,
+)
+
+data class UserPreferenceUpdateRequest(
+    val satisfactionScores: List<Int>,
 )

--- a/backend/src/main/kotlin/com/example/itda/user/persistence/UserEntity.kt
+++ b/backend/src/main/kotlin/com/example/itda/user/persistence/UserEntity.kt
@@ -4,7 +4,6 @@ import com.example.itda.program.persistence.enums.EducationLevel
 import com.example.itda.program.persistence.enums.EmploymentStatus
 import com.example.itda.program.persistence.enums.Gender
 import com.example.itda.program.persistence.enums.MaritalStatus
-import com.pgvector.PGvector
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -13,6 +12,9 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.Array
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.time.LocalDate
 
 @Entity
@@ -46,6 +48,8 @@ class UserEntity(
     @Enumerated(EnumType.STRING)
     @Column(name = "employment_status", nullable = true)
     var employmentStatus: EmploymentStatus? = null,
-    @Column(name = "preference_embedding", columnDefinition = "vector(1024)")
-    var preferenceEmbedding: PGvector? = null,
+    @Column(name = "preference_embedding")
+    @JdbcTypeCode(SqlTypes.VECTOR)
+    @Array(length = 1024)
+    var preferenceEmbedding: FloatArray? = null,
 )


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #70

## ✨ 주요 변경 사항
- 백엔드: 유저선호도api

---

## 📋 작업 내용
### 추가/변경된 내용
- 유저선호 받는 api구현
- 엔티티의 임베딩 자료형 변경

### 작업 상세 설명
1. **유저선호 받는 api구현**: 
`/api/v1/update/preferences`, POST
```
data class UserPreferenceUpdateRequest(
    val satisfactionScores: List<Int>,
)
``` 
다섯개의 정책에 대한 별점(1~5, int) 받아서 유저 선호도 벡터 저장. accesstoken 필요

2. **엔티티의 임베딩 자료형 변경**: 임베딩 자료형 FloatArray로 변경

---

## ✅ 체크리스트
- [x] 코드가 잘 빌드됨
- [x] Linter
- [x] 모든 테스트 통과

---

## ⚠️ 주의 사항
어떤 정책을 기준으로 할지 논의 필요
---

## 📎 참고 자료