### PR TITLE
feat(frontend) #168: splash-screen

### DIFF
--- a/frontend/app/src/androidTest/java/com/example/itda/data/repository/FakeAuthRepository.kt
+++ b/frontend/app/src/androidTest/java/com/example/itda/data/repository/FakeAuthRepository.kt
@@ -11,6 +11,7 @@ class FakeAuthRepository : AuthRepository {
     var loginResult: Result<Unit> = Result.success(Unit)
     var signupResult: Result<Unit> = Result.success(Unit)
     var logoutResult: Result<Unit> = Result.success(Unit)
+    var refreshTokenResult: Result<Unit> = Result.success(Unit)
     var getProfileResult: Result<User> = Result.success(
         User(
             id = "1",
@@ -35,8 +36,10 @@ class FakeAuthRepository : AuthRepository {
     override val isLoggedInFlow: Flow<Boolean> = _isLoggedIn
 
     private var savedEmail: String? = null
+    private var refreshToken: String? = null
 
     var loginCalled = false
+    var refreshTokenCalled = false
     var signupCalled = false
     var logoutCalled = false
     var getProfileCalled = false
@@ -84,9 +87,24 @@ class FakeAuthRepository : AuthRepository {
 
         if (logoutResult.isSuccess) {
             _isLoggedIn.value = false
+            refreshToken = null
         }
 
         return logoutResult
+    }
+
+    override suspend fun getRefreshToken(): String? {
+        return refreshToken
+    }
+
+    override suspend fun refreshToken(): Result<Unit> {
+        refreshTokenCalled = true
+
+        if (refreshTokenResult.isSuccess) {
+            _isLoggedIn.value = true
+        }
+
+        return refreshTokenResult
     }
 
     override suspend fun getProfile(): Result<User> {

--- a/frontend/app/src/main/java/com/example/itda/data/model/Auth.kt
+++ b/frontend/app/src/main/java/com/example/itda/data/model/Auth.kt
@@ -5,6 +5,10 @@ data class AuthRequest(
     val password: String
 )
 
+data class RefreshTokenRequest(
+    val refreshToken: String
+)
+
 data class AuthResponse(
     val accessToken: String,
     val refreshToken: String?,

--- a/frontend/app/src/main/java/com/example/itda/data/repository/AuthRepository.kt
+++ b/frontend/app/src/main/java/com/example/itda/data/repository/AuthRepository.kt
@@ -17,6 +17,10 @@ interface AuthRepository {
 
     suspend fun logout(): Result<Unit>
 
+    suspend fun getRefreshToken(): String?
+
+    suspend fun refreshToken(): Result<Unit>
+
     suspend fun getProfile(): Result<User>
 
     suspend fun updateProfile(request: ProfileUpdateRequest): Result<Unit>

--- a/frontend/app/src/main/java/com/example/itda/data/source/remote/AuthAPI.kt
+++ b/frontend/app/src/main/java/com/example/itda/data/source/remote/AuthAPI.kt
@@ -4,6 +4,7 @@ import com.example.itda.data.model.AuthRequest
 import com.example.itda.data.model.AuthResponse
 import com.example.itda.data.model.PreferenceRequestList
 import com.example.itda.data.model.ProfileRequest
+import com.example.itda.data.model.RefreshTokenRequest
 import com.example.itda.data.model.User
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -19,6 +20,9 @@ interface AuthAPI {
 
     @POST("auth/logout")
     suspend fun logout()
+
+    @POST("auth/refresh")
+    suspend fun refreshToken(@Body request: RefreshTokenRequest): AuthResponse
 
     @GET("my-profile")
     suspend fun getProfile(): User

--- a/frontend/app/src/main/java/com/example/itda/data/source/remote/RetrofitInstance.kt
+++ b/frontend/app/src/main/java/com/example/itda/data/source/remote/RetrofitInstance.kt
@@ -61,7 +61,7 @@ object RetrofitInstance {
             .build()
     }
 
-    // API 인터페이스 - 이 아래 추가해주시면 됩니다!
+    // API 인터페이스
     val authAPI: AuthAPI by lazy {
         retrofit.create(AuthAPI::class.java)
     }

--- a/frontend/app/src/main/java/com/example/itda/ui/navigation/AppNavHost.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/navigation/AppNavHost.kt
@@ -16,7 +16,7 @@ fun AppNavHost() {
 
     val isLoadingInitial by authViewModel.isLoadingInitial.collectAsState()
     if (isLoadingInitial) {
-        LoadingScreen()
+        SplashScreen()
         return
     }
     val isLoggedIn by authViewModel.isLoggedIn.collectAsState() // 로그인 여부

--- a/frontend/app/src/main/java/com/example/itda/ui/navigation/SplashScreen.kt
+++ b/frontend/app/src/main/java/com/example/itda/ui/navigation/SplashScreen.kt
@@ -1,0 +1,134 @@
+package com.example.itda.ui.navigation
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.itda.ui.common.theme.*
+
+@Composable
+fun SplashScreen(modifier: Modifier = Modifier) {
+    var progress by remember { mutableFloatStateOf(0f) }
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress,
+        animationSpec = tween(durationMillis = 1500, easing = EaseInOut),
+        label = "splash_progress"
+    )
+
+    var textAlpha by remember { mutableFloatStateOf(0f) }
+    val animatedTextAlpha by animateFloatAsState(
+        targetValue = textAlpha,
+        animationSpec = tween(durationMillis = 800, easing = EaseInOut),
+        label = "text_fade_in"
+    )
+
+    LaunchedEffect(Unit) {
+        progress = 1f
+        kotlinx.coroutines.delay(500)
+        textAlpha = 1f
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        SplashBubbles(progress = animatedProgress)
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .graphicsLayer { alpha = animatedTextAlpha },
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "숨은 복지와 당신을",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.Black
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "잇다",
+                fontSize = 65.sp,
+                fontWeight = FontWeight.Bold,
+                color = Primary40
+            )
+        }
+    }
+}
+
+@Composable
+private fun SplashBubbles(progress: Float) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        val reverseProgress = 1.0f - progress
+
+        val rotation1 = reverseProgress * 90f
+        val alpha1 = progress.coerceIn(0f, 1f)
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .offset(x = 60.dp, y = (-80).dp)
+                .graphicsLayer {
+                    rotationZ = rotation1
+                    translationX = reverseProgress * (-size.width) * 0.6f
+                    translationY = reverseProgress * size.height * 0.6f
+                    alpha = alpha1
+                }
+                .size(280.dp)
+                .clip(CircleShape)
+                .background(Primary60.copy(alpha = 0.4f))
+        )
+
+        val rotation2 = reverseProgress * (-90f)
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .offset(x = (-40).dp, y = 50.dp)
+                .graphicsLayer {
+                    rotationZ = rotation2
+                    translationX = reverseProgress * size.width * 0.6f
+                    translationY = reverseProgress * (-size.height) * 0.4f
+                    alpha = alpha1
+                }
+                .size(240.dp)
+                .clip(CircleShape)
+                .background(Primary70.copy(alpha = 0.6f))
+        )
+
+        val scale3 = progress.coerceIn(0f, 1f)
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .offset(x = 160.dp, y = (-120).dp)
+                .graphicsLayer {
+                    scaleX = scale3
+                    scaleY = scale3
+                    alpha = alpha1
+                }
+                .size(150.dp)
+                .clip(CircleShape)
+                .background(Primary80.copy(alpha = 0.4f))
+        )
+    }
+}

--- a/frontend/app/src/test/java/com/example/itda/ui/auth/AuthViewModelTest.kt
+++ b/frontend/app/src/test/java/com/example/itda/ui/auth/AuthViewModelTest.kt
@@ -44,9 +44,8 @@ class AuthViewModelTest {
 
     @Before
     fun setup() = runBlocking {
-        val isLoggedInFlow = MutableStateFlow(false)
-        Mockito.`when`(authRepository.isLoggedInFlow).thenReturn(isLoggedInFlow)
         Mockito.`when`(authRepository.getSavedEmail()).thenReturn(null)
+        Mockito.`when`(authRepository.getRefreshToken()).thenReturn(null)
         Mockito.`when`(programRepository.getExamples()).thenReturn(Result.success(emptyList()))
 
         viewModel = AuthViewModel(authRepository, programRepository)
@@ -56,9 +55,9 @@ class AuthViewModelTest {
 
     @Test
     fun init_loadsLoggedInState() = runTest {
-        val isLoggedInFlow = MutableStateFlow(true)
-        Mockito.`when`(authRepository.isLoggedInFlow).thenReturn(isLoggedInFlow)
         Mockito.`when`(authRepository.getSavedEmail()).thenReturn(null)
+        Mockito.`when`(authRepository.getRefreshToken()).thenReturn("fake-refresh-token")
+        Mockito.`when`(authRepository.refreshToken()).thenReturn(Result.success(Unit))
         Mockito.`when`(programRepository.getExamples()).thenReturn(Result.success(emptyList()))
 
         val vm = AuthViewModel(authRepository, programRepository)
@@ -69,9 +68,8 @@ class AuthViewModelTest {
 
     @Test
     fun init_loadsSavedEmail() = runTest {
-        val isLoggedInFlow = MutableStateFlow(false)
-        Mockito.`when`(authRepository.isLoggedInFlow).thenReturn(isLoggedInFlow)
         Mockito.`when`(authRepository.getSavedEmail()).thenReturn("saved@test.com")
+        Mockito.`when`(authRepository.getRefreshToken()).thenReturn(null)
         Mockito.`when`(programRepository.getExamples()).thenReturn(Result.success(emptyList()))
 
         val vm = AuthViewModel(authRepository, programRepository)
@@ -87,9 +85,8 @@ class AuthViewModelTest {
 
     @Test
     fun init_noSavedEmail() = runTest {
-        val isLoggedInFlow = MutableStateFlow(false)
-        Mockito.`when`(authRepository.isLoggedInFlow).thenReturn(isLoggedInFlow)
         Mockito.`when`(authRepository.getSavedEmail()).thenReturn(null)
+        Mockito.`when`(authRepository.getRefreshToken()).thenReturn(null)
         Mockito.`when`(programRepository.getExamples()).thenReturn(Result.success(emptyList()))
 
         val vm = AuthViewModel(authRepository, programRepository)


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #168

## ✨ 주요 변경 사항
- 프론트엔드: 리프레시 토큰 구현, 버그 해결, 스플래시 스크린 구현. 

---

## 📋 작업 내용
### 추가/변경된 내용
- 리프레시 토큰 연결
- 스플래시 스크린 구현

### 작업 상세 설명
1. **리프레시 토큰 연결**: 리프레시 토큰 api와 연결하였습니다. 이를 통해 토큰이 만료되어 로그인이 되면 안되는 상황이지만, 토큰이 존재하긴 하여 isLoggedin이 true가 되어 토큰 없이 main graph로 들어가지던 버그를 해결했습니다.
2. **스플래시 스크린 구현**: 리프레시 토큰 검증 과정에 있어 시간이 이전보다 꽤 걸리도 하고, 미적으로도 있으면 좋을 것 같아 스플래시 스크린을 구현했습니다. 디자인이 미흡한 부분이 있지만 차차 수정하면 좋을 것 같습니다. 

---

## ✅ 체크리스트
- [x] 코드가 잘 빌드됨
- [x] Linter
- [x] 모든 테스트 통과

---

## 📎 참고 자료
- [Refresh Token, Access Token 을 활용한 로그인 코드구현](https://velog.io/@msung99/Spring-Security-Refresh-Token-Access-Token-%EC%9D%84-%EC%BD%94%EB%93%9C%EB%A1%9C-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EC%9E%90)
