### PR TITLE
fix(be) #178 : address matching + Test

### DIFF
--- a/backend/src/main/kotlin/com/example/itda/program/persistence/ProgramRepository.kt
+++ b/backend/src/main/kotlin/com/example/itda/program/persistence/ProgramRepository.kt
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param
 
 interface ProgramRepository : JpaRepository<ProgramEntity, Long> {
     @Query(
-        // TODO: Address
         value = """
         SELECT p.*
         FROM program p
@@ -24,6 +23,19 @@ interface ProgramRepository : JpaRepository<ProgramEntity, Long> {
         AND (p.eligibility_employment is NULL OR p.eligibility_employment = u.employment_status)
         AND (p.eligibility_min_age IS NULL OR u.birth_date IS NULL OR p.eligibility_min_age <= DATE_PART('year', AGE(CURRENT_DATE, u.birth_date)))
         AND (p.eligibility_max_age IS NULL OR u.birth_date IS NULL OR p.eligibility_max_age >= DATE_PART('year', AGE(CURRENT_DATE, u.birth_date)))
+        
+        LEFT JOIN postcode_mapping pm ON pm.postcode_prefix = SUBSTRING(u.postcode, 1, 3)
+        WHERE (
+            p.operating_entity_type = 'CENTRAL'
+            OR (
+                p.operating_entity_type = 'LOCAL' 
+                AND (
+                    p.eligibility_region = pm.region 
+                    OR 
+                    p.eligibility_region = pm.region_major
+                )
+            )
+        )
         """,
         nativeQuery = true,
     )

--- a/backend/src/main/kotlin/com/example/itda/user/persistence/PostcodeMappingEntity.kt
+++ b/backend/src/main/kotlin/com/example/itda/user/persistence/PostcodeMappingEntity.kt
@@ -1,0 +1,18 @@
+package com.example.itda.user.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "postcode_mapping")
+class PostcodeMappingEntity(
+    @Id
+    @Column(name = "postcode_prefix", length = 3, nullable = false)
+    val postcodePrefix: String,
+    @Column(name = "region", nullable = false)
+    val region: String,
+    @Column(name = "region_major", nullable = false)
+    val regionMajor: String,
+)

--- a/backend/src/test/kotlin/com/example/itda/DataGenerator.kt
+++ b/backend/src/test/kotlin/com/example/itda/DataGenerator.kt
@@ -83,8 +83,8 @@ class DataGenerator(
                 summary = "Summary for $title",
                 details = "Details for $title",
                 category = category,
-                operatingEntityType = OperatingEntityType.LOCAL,
-                operatingEntity = "Local Entity $title",
+                operatingEntityType = OperatingEntityType.CENTRAL,
+                operatingEntity = "Operating Entity $title",
                 preview = "Preview for $title",
                 embedding = embeddingValues,
             )


### PR DESCRIPTION
# 📌 Pull Request Template

## 🔍 관련 이슈
- 이슈 번호: #178

## ✨ 주요 변경 사항
- 백엔드: address matching + test code

---

## 📋 작업 내용
### 추가/변경된 내용
- address matching
- Test code

### 작업 상세 설명
1. **address matching**: postcode_mapping 테이블 추가해서 지역이름과 우편번호 앞자리 정보 저장하고, 매칭할 때 써먹었습니다.
2. **test**: 추가됐던 api들 테스트코드 추가했습니다. embedding서버 관련은 추가 못했습니다. 

---

## ✅ 체크리스트
- [x] 코드가 잘 빌드됨
- [x] Linter
- [x] 모든 테스트 통과

---

## ⚠️ 주의 사항
.

## 📎 참고 자료
.
